### PR TITLE
Add Supabase auth demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# ChatGPT
-Para pruebas con ChatPGT
+# ChatGPT Demo
+
+Este repositorio contiene una página estática publicada con **GitHub Pages**. Incluye un pequeño ejemplo de autenticación con [Supabase](https://supabase.com/).
+
+## Configuración
+
+1. Crea un proyecto en Supabase y habilita el registro por correo electrónico.
+2. Copia la URL del proyecto y la "anon key" desde la sección de API.
+3. Edita el archivo `main.js` y reemplaza `YOUR-PROJECT.supabase.co` y `YOUR-ANON-KEY` por tus valores reales.
+4. Haz *push* de los cambios a la rama que utilices para GitHub Pages (`main` o `work`).
+
+Al acceder a `https://<usuario>.github.io/<repositorio>/` podrás registrarte, iniciar sesión y cerrar sesión usando Supabase Auth. El contador del ejemplo funciona de manera local y no requiere backend.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Mi página GitHub Pages</title>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script defer src="main.js"></script>
+</head>
+<body>
+  <h1>¡Hola, mundo!</h1>
+  <p>Esta es mi página publicada con GitHub Pages.</p>
+
+  <h2>Registro</h2>
+  <form id="signup-form">
+    <input type="email" id="signup-email" placeholder="Correo" required>
+    <input type="password" id="signup-password" placeholder="Contraseña" required>
+    <button type="submit">Registrarse</button>
+  </form>
+
+  <h2>Inicio de sesión</h2>
+  <form id="login-form">
+    <input type="email" id="login-email" placeholder="Correo" required>
+    <input type="password" id="login-password" placeholder="Contraseña" required>
+    <button type="submit">Iniciar sesión</button>
+  </form>
+
+  <button id="logout-button" style="display:none;">Cerrar sesión</button>
+
+  <h2>Contador</h2>
+  <button id="counterButton">Haz clic</button>
+  <p id="clickCount">0</p>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,50 @@
+// Configura tu proyecto de Supabase
+const supabaseUrl = 'https://YOUR-PROJECT.supabase.co'; // Reemplaza con tu URL
+const supabaseKey = 'YOUR-ANON-KEY'; // Reemplaza con tu anon key
+const supabase = supabase.createClient(supabaseUrl, supabaseKey);
+
+// Registro de usuario
+const signupForm = document.getElementById('signup-form');
+signupForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('signup-email').value;
+  const password = document.getElementById('signup-password').value;
+  const { error } = await supabase.auth.signUp({ email, password });
+  if (error) {
+    alert('Error al registrarse: ' + error.message);
+  } else {
+    alert('Registro exitoso. Revisa tu correo para confirmar.');
+  }
+});
+
+// Inicio de sesión
+const loginForm = document.getElementById('login-form');
+loginForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = document.getElementById('login-email').value;
+  const password = document.getElementById('login-password').value;
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) {
+    alert('Error al iniciar sesión: ' + error.message);
+  } else {
+    alert('Sesión iniciada');
+    document.getElementById('logout-button').style.display = 'block';
+  }
+});
+
+// Cerrar sesión
+const logoutButton = document.getElementById('logout-button');
+logoutButton.addEventListener('click', async () => {
+  await supabase.auth.signOut();
+  alert('Sesión cerrada');
+  document.getElementById('logout-button').style.display = 'none';
+});
+
+// Contador de ejemplo
+const button = document.getElementById('counterButton');
+const countDisplay = document.getElementById('clickCount');
+let count = 0;
+button.addEventListener('click', () => {
+  count += 1;
+  countDisplay.textContent = count;
+});


### PR DESCRIPTION
## Summary
- add README instructions for Supabase
- expand `index.html` with registration and login forms
- add `main.js` for Supabase auth logic and counter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684046e1dee88326a70c93f039c7511e