### PR TITLE
Update README about Supabase client initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ Este repositorio contiene una página estática publicada con **GitHub Pages**. 
 2. Copia la URL del proyecto y la "anon key" desde la sección de API.
 3. Edita el archivo `main.js` y reemplaza `YOUR-PROJECT.supabase.co` y `YOUR-ANON-KEY` por tus valores reales.
 4. Haz *push* de los cambios a la rama que utilices para GitHub Pages (`main` o `work`).
+5. El cliente se guarda en `supabaseClient = supabase.createClient(...)`. No lo nombres `supabase` porque esa variable ya la define la librería y producirá un error de inicialización.
 
 Al acceder a `https://<usuario>.github.io/<repositorio>/` podrás registrarte, iniciar sesión y cerrar sesión usando Supabase Auth. El contador del ejemplo funciona de manera local y no requiere backend.


### PR DESCRIPTION
## Summary
- clarify that the Supabase client is stored in `supabaseClient`
- warn against naming it `supabase` to avoid initialization errors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684239de8a288326bcb4260f7ac23f8a