### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # ChatGPT
-Para pruebas con ChatPGT
+Para pruebas con ChatGPT


### PR DESCRIPTION
## Summary
- fix small typo in README so that it references ChatGPT correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840466660d483268db15ab703aa96d6